### PR TITLE
Add basic EatTogether skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This repository now contains a starter project for **EatTogether**, a simple foo
 # Usage
 
 1. Install dependencies inside `backend` and `frontend` directories with `npm install`.
+   If needed, you can manually install the backend dependencies with:
+   `npm install express mongoose dotenv cors jsonwebtoken bcrypt`
 2. Start MongoDB locally or provide a connection string in the `MONGO_URI` environment variable.
 3. Run `node server.js` inside `backend` to start the API server.
 4. Open `frontend/public/index.html` in a browser to load the React app.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# EatTogether Platform Skeleton
+
+This repository now contains a starter project for **EatTogether**, a simple food ordering platform built with React and Node.js. The goal is to demonstrate a basic setup that includes authentication for two user roles (customer and chef) and minimal dashboards for each role.
+
+# Usage
+
+1. Install dependencies inside `backend` and `frontend` directories with `npm install`.
+2. Start MongoDB locally or provide a connection string in the `MONGO_URI` environment variable.
+3. Run `node server.js` inside `backend` to start the API server.
+4. Open `frontend/public/index.html` in a browser to load the React app.
+
 # Welcome to Gallic Acids
 
 Gallic acid is a type of phenolic acid commonly found in various plants, fruits, and teas. It is known for its antioxidant, antimicrobial, and anti-inflammatory properties.

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,13 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = function(req, res, next) {
+  const token = req.header('Authorization') && req.header('Authorization').split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'No token, authorization denied' });
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secretkey');
+    req.user = decoded;
+    next();
+  } catch (err) {
+    res.status(401).json({ message: 'Token is not valid' });
+  }
+};

--- a/backend/models/Menu.js
+++ b/backend/models/Menu.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const MenuSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  description: String,
+  ingredients: [String],
+  allergens: [String],
+  chef: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  tags: [String] // spicy, sweet, etc
+});
+
+module.exports = mongoose.model('Menu', MenuSchema);

--- a/backend/models/Order.js
+++ b/backend/models/Order.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const OrderSchema = new mongoose.Schema({
+  customer: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  menu: { type: mongoose.Schema.Types.ObjectId, ref: 'Menu' },
+  status: { type: String, enum: ['preparing', 'cooking', 'ready'], default: 'preparing' },
+  qrCode: String // placeholder for qr link
+}, { timestamps: true });
+
+module.exports = mongoose.model('Order', OrderSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -1,5 +1,5 @@
 const mongoose = require('mongoose');
-const bcrypt = require('bcryptjs');
+const bcrypt = require('bcrypt');
 
 const UserSchema = new mongoose.Schema({
   name: { type: String, required: true },

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -1,0 +1,25 @@
+const mongoose = require('mongoose');
+const bcrypt = require('bcryptjs');
+
+const UserSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+  role: { type: String, enum: ['customer', 'chef'], required: true },
+  preferences: {
+    tastes: [String], // spicy, sweet, etc
+    allergies: [String]
+  }
+});
+
+UserSchema.pre('save', async function(next) {
+  if (!this.isModified('password')) return next();
+  this.password = await bcrypt.hash(this.password, 10);
+  next();
+});
+
+UserSchema.methods.comparePassword = function(candidate) {
+  return bcrypt.compare(candidate, this.password);
+};
+
+module.exports = mongoose.model('User', UserSchema);

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "eattogether-backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.0",
+    "mongoose": "^7.3.1"
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,8 +6,9 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "bcryptjs": "^2.4.3",
+    "bcrypt": "^5.1.0",
     "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
     "mongoose": "^7.3.1"

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,31 @@
+const router = require('express').Router();
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+// Register
+router.post('/register', async (req, res) => {
+  try {
+    const user = new User(req.body);
+    await user.save();
+    res.json({ message: 'User registered' });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Login
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  try {
+    const user = await User.findOne({ email });
+    if (!user) throw new Error('User not found');
+    const isMatch = await user.comparePassword(password);
+    if (!isMatch) throw new Error('Invalid credentials');
+    const token = jwt.sign({ id: user._id, role: user.role }, process.env.JWT_SECRET || 'secretkey');
+    res.json({ token, role: user.role, userId: user._id });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/menus.js
+++ b/backend/routes/menus.js
@@ -1,0 +1,23 @@
+const router = require('express').Router();
+const Menu = require('../models/Menu');
+const auth = require('../middleware/auth');
+
+// Get all menus
+router.get('/', async (req, res) => {
+  const menus = await Menu.find().populate('chef', 'name');
+  res.json(menus);
+});
+
+// Create menu (chef only)
+router.post('/', auth, async (req, res) => {
+  if (req.user.role !== 'chef') return res.status(403).json({ message: 'Only chefs can create menus' });
+  try {
+    const menu = new Menu({ ...req.body, chef: req.user.id });
+    await menu.save();
+    res.json(menu);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/orders.js
+++ b/backend/routes/orders.js
@@ -1,0 +1,39 @@
+const router = require('express').Router();
+const Order = require('../models/Order');
+const Menu = require('../models/Menu');
+const auth = require('../middleware/auth');
+
+// Create order (customer)
+router.post('/', auth, async (req, res) => {
+  if (req.user.role !== 'customer') return res.status(403).json({ message: 'Only customers can order' });
+  try {
+    const menu = await Menu.findById(req.body.menuId);
+    const order = new Order({ customer: req.user.id, menu: menu._id, qrCode: `http://example.com/orders/${req.user.id}` });
+    await order.save();
+    res.json(order);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Update status (chef)
+router.put('/:id/status', auth, async (req, res) => {
+  if (req.user.role !== 'chef') return res.status(403).json({ message: 'Only chefs can update status' });
+  try {
+    const order = await Order.findById(req.params.id).populate('menu');
+    if (!order.menu.chef.equals(req.user.id)) return res.status(403).json({ message: 'Not your order' });
+    order.status = req.body.status;
+    await order.save();
+    res.json(order);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Get orders for user
+router.get('/', auth, async (req, res) => {
+  const orders = await Order.find({ [req.user.role]: req.user.id }).populate('menu');
+  res.json(orders);
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const cors = require('cors');
+const authRoutes = require('./routes/auth');
+const menuRoutes = require('./routes/menus');
+const orderRoutes = require('./routes/orders');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.use('/api/auth', authRoutes);
+app.use('/api/menus', menuRoutes);
+app.use('/api/orders', orderRoutes);
+
+const PORT = process.env.PORT || 5000;
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/eattogether';
+
+mongoose.connect(MONGO_URI, { useNewUrlParser: true, useUnifiedTopology: true })
+  .then(() => {
+    console.log('MongoDB connected');
+    app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+  })
+  .catch(err => console.error(err));

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "eattogether-frontend",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EatTogether</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+</head>
+<body class="bg-gray-100">
+  <div id="root"></div>
+  <script src="../src/index.js" type="module"></script>
+</body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import Login from './Login.js';
+import DashboardCustomer from './DashboardCustomer.js';
+import DashboardChef from './DashboardChef.js';
+
+export default function App() {
+  const [token, setToken] = useState(localStorage.getItem('token'));
+  const [role, setRole] = useState(localStorage.getItem('role'));
+
+  const handleLogin = (tk, rl) => {
+    localStorage.setItem('token', tk);
+    localStorage.setItem('role', rl);
+    setToken(tk);
+    setRole(rl);
+  };
+
+  const logout = () => {
+    localStorage.clear();
+    setToken(null);
+    setRole(null);
+  };
+
+  if (!token) return <Login onLogin={handleLogin} />;
+  if (role === 'customer') return <DashboardCustomer onLogout={logout} />;
+  if (role === 'chef') return <DashboardChef onLogout={logout} />;
+  return <div>Unknown role</div>;
+}

--- a/frontend/src/DashboardChef.js
+++ b/frontend/src/DashboardChef.js
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+
+export default function DashboardChef({ onLogout }) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [menus, setMenus] = useState([]);
+
+  const loadMenus = () => {
+    fetch('/api/menus').then(res => res.json()).then(data => setMenus(data));
+  };
+
+  useEffect(() => {
+    loadMenus();
+  }, []);
+
+  const submit = async e => {
+    e.preventDefault();
+    await fetch('/api/menus', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + localStorage.getItem('token')
+      },
+      body: JSON.stringify({ name, description })
+    });
+    setName('');
+    setDescription('');
+    loadMenus();
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Chef Dashboard</h1>
+      <button className="mb-4" onClick={onLogout}>Logout</button>
+      <form onSubmit={submit} className="mb-4">
+        <input className="border p-2 mr-2" placeholder="Menu name" value={name} onChange={e => setName(e.target.value)} />
+        <input className="border p-2 mr-2" placeholder="Description" value={description} onChange={e => setDescription(e.target.value)} />
+        <button className="bg-green-500 text-white px-4 py-2" type="submit">Add</button>
+      </form>
+      <ul>
+        {menus.filter(m => m.chef && m.chef._id === localStorage.getItem('userId')).map(menu => (
+          <li key={menu._id} className="border p-2 mb-2">
+            <h2 className="font-bold">{menu.name}</h2>
+            <p>{menu.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/DashboardCustomer.js
+++ b/frontend/src/DashboardCustomer.js
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+
+export default function DashboardCustomer({ onLogout }) {
+  const [menus, setMenus] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/menus').then(res => res.json()).then(setMenus);
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Customer Dashboard</h1>
+      <button className="mb-4" onClick={onLogout}>Logout</button>
+      <ul>
+        {menus.map(menu => (
+          <li key={menu._id} className="border p-2 mb-2">
+            <h2 className="font-bold">{menu.name}</h2>
+            <p>{menu.description}</p>
+            <p className="text-sm">Ingredients: {menu.ingredients.join(', ')}</p>
+            <p className="text-sm text-red-500">Allergens: {menu.allergens.join(', ')}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+
+export default function Login({ onLogin }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const submit = async e => {
+    e.preventDefault();
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+    const data = await res.json();
+    if (data.token) {
+      localStorage.setItem('userId', data.userId);
+      onLogin(data.token, data.role);
+    }
+    else alert(data.error);
+  };
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <form className="bg-white p-6 rounded shadow" onSubmit={submit}>
+        <h1 className="mb-4 text-xl">Login</h1>
+        <input className="border p-2 mb-2 w-full" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+        <input className="border p-2 mb-2 w-full" placeholder="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
+        <button className="bg-blue-500 text-white px-4 py-2" type="submit">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,6 @@
+import App from './App.js';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);


### PR DESCRIPTION
## Summary
- add EatTogether backend with Express, MongoDB models and REST routes
- add frontend React screens and Tailwind styling
- document usage in README

## Testing
- `node --check backend/server.js`
- `node --check backend/routes/auth.js`
- `node --check backend/routes/menus.js`
- `node --check backend/routes/orders.js`
- `node backend/server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684db3ead8b083259df8b98e30de0e6a